### PR TITLE
Add roster JSON import + QR-label / USB-scanner integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ AWS_REGION=us-east-1
 # Database Configuration (Optional)
 # DATABASE_URL=sqlite:///arcade.db
 
+# Public base URL baked into printed QR machine labels (Optional).
+# Set this so phone-camera scans of a label open the app directly.
+# If unset, labels use the request host (fine for local/USB-scanner use).
+# BASE_URL=http://192.168.1.50:5000
+
 # Security Configuration (Change in production!)
 SECRET_KEY=your-secret-key-change-this-for-production
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -73,6 +73,10 @@ def _configure_app(app: Flask) -> None:
     app.config["UPLOAD_FOLDER"] = os.path.join(base_dir, "uploads")
     app.config["MAX_CONTENT_LENGTH"] = 50 * 1024 * 1024  # 50 MB
 
+    # Public base URL baked into printed QR labels (e.g. http://pi-host:5000).
+    # Falls back to the request host when unset, so scanning still works locally.
+    app.config["BASE_URL"] = os.environ.get("BASE_URL", "")
+
     # CSRF ---------------------------------------------------------
     app.config["WTF_CSRF_CHECK_DEFAULT"] = False
 

--- a/app/models/game.py
+++ b/app/models/game.py
@@ -14,6 +14,7 @@ class Game(db.Model):
 
     id: int = db.Column(db.Integer, primary_key=True)
     name: str = db.Column(db.String(100), nullable=False)
+    barcode: str | None = db.Column(db.String(64), unique=True, nullable=True)
     manufacturer: str | None = db.Column(db.String(50), nullable=True)
     year: int | None = db.Column(db.Integer, nullable=True)
     genre: str | None = db.Column(db.String(50), nullable=True)

--- a/app/routes/games.py
+++ b/app/routes/games.py
@@ -2,12 +2,14 @@
 
 import io
 import os
+import json
 import uuid
 import datetime as dt
 from datetime import datetime, date
 
 from flask import (
     Blueprint,
+    abort,
     current_app,
     flash,
     make_response,
@@ -22,7 +24,11 @@ from werkzeug.utils import secure_filename
 from app.extensions import db
 from app.models import Game, PlayRecord, MaintenanceRecord
 from app.utils.decorators import requires_role
-from app.utils.helpers import allowed_file
+from app.utils.helpers import (
+    allowed_file,
+    generate_unique_barcode,
+    import_games_from_roster,
+)
 
 games_bp = Blueprint("games", __name__)
 
@@ -126,8 +132,13 @@ def add_game():
                 file.save(filepath)
                 image_filename = filename
 
+        # Assign a stable barcode/QR slug from the name
+        taken_barcodes = {b for (b,) in db.session.query(Game.barcode).all() if b}
+        barcode = generate_unique_barcode(name, taken_barcodes)
+
         game = Game(
             name=name,
+            barcode=barcode,
             manufacturer=manufacturer,
             year=year,
             genre=genre,
@@ -612,3 +623,105 @@ def export_selected_games():
     response.headers["Content-type"] = "text/csv"
 
     return response
+
+
+@games_bp.route("/import_games", methods=["GET", "POST"])
+@login_required
+@requires_role("manager")
+def import_games():
+    """Bulk-import games from an uploaded barcade-roster JSON file.
+
+    Accepts the ``catbox-barcade-roster.json`` structure (``video_games`` /
+    ``pinball`` / ``retired`` arrays + ``meta.platforms``). Idempotent: existing
+    games (matched by name) are skipped, so re-uploading never duplicates.
+    """
+    if request.method == "POST":
+        file = request.files.get("file")
+        if not file or file.filename == "":
+            flash("No file selected.", "error")
+            return redirect(url_for("games.import_games"))
+
+        try:
+            data = json.load(file.stream)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            flash(f"Not valid JSON: {exc}", "error")
+            return redirect(url_for("games.import_games"))
+
+        if not isinstance(data, dict) or not any(
+            k in data for k in ("video_games", "pinball", "retired")
+        ):
+            flash(
+                "JSON is missing the expected 'video_games' / 'pinball' / "
+                "'retired' arrays.",
+                "error",
+            )
+            return redirect(url_for("games.import_games"))
+
+        try:
+            result = import_games_from_roster(data)
+            db.session.commit()
+        except Exception as exc:  # noqa: BLE001
+            db.session.rollback()
+            flash(f"Import failed: {exc}", "error")
+            return redirect(url_for("games.import_games"))
+
+        msg = (
+            f"Import complete: {result['added']} added, "
+            f"{result['skipped']} skipped (already present)."
+        )
+        flash(msg, "success" if not result["errors"] else "warning")
+        for err in result["errors"][:10]:
+            flash(err, "error")
+        return redirect(url_for("games.games_list"))
+
+    return render_template("import_games.html")
+
+
+@games_bp.route("/scan")
+@login_required
+def scan():
+    """Kiosk page: a focused input a USB HID barcode scanner types into."""
+    return render_template("scan.html")
+
+
+@games_bp.route("/g/<code>")
+@login_required
+def resolve_barcode(code):
+    """Resolve a scanned barcode/QR payload to a game's maintenance page.
+
+    Matches on the ``barcode`` slug first, then falls back to a numeric id so
+    labels that encode the raw database id still resolve.
+    """
+    game = Game.query.filter_by(barcode=code).first()
+    if game is None and code.isdigit():
+        game = Game.query.get(int(code))
+    if game is None:
+        flash(f"No machine found for scanned code '{code}'.", "error")
+        return redirect(url_for("games.scan"))
+    return redirect(url_for("maintenance.game_maintenance", game_id=game.id))
+
+
+@games_bp.route("/game/<int:game_id>/label")
+@login_required
+def game_label(game_id):
+    """Printable QR label for a game, encoding a link to its maintenance page."""
+    import segno
+
+    game = Game.query.get_or_404(game_id)
+
+    # Backfill a barcode on the fly for any legacy row that lacks one.
+    if not game.barcode:
+        taken = {b for (b,) in db.session.query(Game.barcode).all() if b}
+        game.barcode = generate_unique_barcode(game.name, taken)
+        db.session.commit()
+
+    base_url = (current_app.config.get("BASE_URL") or request.host_url).rstrip("/")
+    label_url = f"{base_url}/g/{game.barcode}"
+    qr_data_uri = segno.make(label_url, error="m").svg_data_uri(scale=6, border=2)
+
+    return render_template(
+        "game_label.html",
+        game=game,
+        label_url=label_url,
+        qr_data_uri=qr_data_uri,
+    )

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import time
 from pathlib import Path
 
@@ -102,6 +103,142 @@ def cleanup_old_photos(max_age_days: int = 365) -> int:
             removed += 1
 
     return removed
+
+
+def slugify(text: str) -> str:
+    """Return a lowercase, hyphenated slug of *text* (a-z, 0-9 and hyphens only)."""
+    text = (text or "").lower().strip()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    return text.strip("-")
+
+
+def generate_unique_barcode(name: str, taken: set[str]) -> str:
+    """Build a stable, unique barcode slug from *name*.
+
+    Deterministic from the game name (so a rebuilt DB regenerates the same
+    labels), with a numeric suffix only when the base slug is already used by a
+    different game (e.g. the video *Batman* vs the pinball *Batman*). The
+    chosen slug is added to *taken* so callers can keep it unique across a batch.
+    """
+    base = (slugify(name) or "game")[:60]
+    candidate = base
+    n = 2
+    while candidate in taken:
+        candidate = f"{base}-{n}"
+        n += 1
+    taken.add(candidate)
+    return candidate
+
+
+def _dedupe(items: list) -> list:
+    """Return *items* with duplicates removed, preserving first-seen order."""
+    seen: set = set()
+    out: list = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+def _compose_service_notes(entry: dict, platforms: dict) -> str | None:
+    """Build a human-readable service block from a roster entry + its platform.
+
+    Merges the platform's shared ``desc``/``faults``/``parts``/``pm`` with the
+    entry's own ``risk``/``faults``/``parts``/``notes`` so the recovered record
+    carries the maintenance intel, not just the name.
+    """
+    lines: list[str] = []
+    plat = platforms.get(entry.get("platform")) if entry.get("platform") else None
+
+    if plat and plat.get("desc"):
+        lines.append(f"Platform: {plat['desc']}")
+
+    risk = entry.get("risk") or []
+    if risk:
+        lines.append("Risk flags: " + ", ".join(risk))
+
+    faults = _dedupe(
+        list(plat.get("faults", []) if plat else []) + list(entry.get("faults") or [])
+    )
+    if faults:
+        lines.append("Known faults: " + "; ".join(faults))
+
+    parts = _dedupe(
+        list(plat.get("parts", []) if plat else []) + list(entry.get("parts") or [])
+    )
+    if parts:
+        lines.append("Parts: " + "; ".join(parts))
+
+    if plat and plat.get("pm"):
+        lines.append("PM: " + plat["pm"])
+
+    if entry.get("notes"):
+        lines.append("Notes: " + entry["notes"])
+
+    return "\n".join(lines) if lines else None
+
+
+def import_games_from_roster(data: dict) -> dict:
+    """Import games from a barcade-roster JSON structure into the database.
+
+    Consumes the ``catbox-barcade-roster.json`` schema: ``video_games`` /
+    ``pinball`` / ``retired`` arrays plus a shared ``meta.platforms`` service
+    dictionary. Idempotent — matches existing games by name (case-insensitive)
+    and skips them, so re-running never creates duplicates. The caller is
+    responsible for ``db.session.commit()``.
+
+    Returns:
+        ``{"added": int, "skipped": int, "errors": list[str]}``.
+    """
+    from app.extensions import db
+    from app.models import Game
+
+    platforms = (data.get("meta") or {}).get("platforms") or {}
+    result: dict = {"added": 0, "skipped": 0, "errors": []}
+
+    # Names already in the DB *before* this import. We only skip against these,
+    # not against rows added during this run — the roster legitimately contains
+    # distinct machines that share a name (e.g. a Batman video game AND a Batman
+    # pinball), and both must import. Re-running stays idempotent because the
+    # second run sees both already in the DB.
+    existing = Game.query.all()
+    names_lower = {g.name.strip().lower() for g in existing if g.name}
+    taken_barcodes = {g.barcode for g in existing if g.barcode}
+
+    # (array key, default location, default status, is_pinball)
+    sections = [
+        ("video_games", "Floor", "Working", False),
+        ("pinball", "Floor", "Working", True),
+        ("retired", "Warehouse", "Retired", False),
+    ]
+
+    for key, default_location, default_status, is_pinball in sections:
+        for entry in data.get(key) or []:
+            try:
+                name = (entry.get("name") or "").strip()
+                if not name:
+                    result["errors"].append(f"{key}: entry with no name skipped")
+                    continue
+                if name.lower() in names_lower:
+                    result["skipped"] += 1
+                    continue
+
+                game = Game(
+                    name=name,
+                    barcode=generate_unique_barcode(name, taken_barcodes),
+                    manufacturer=(entry.get("mfr") or None),
+                    location=default_location,
+                    status=default_status,
+                    genre="Pinball" if is_pinball else None,
+                    notes=_compose_service_notes(entry, platforms),
+                )
+                db.session.add(game)
+                result["added"] += 1
+            except Exception as exc:  # noqa: BLE001 - report per-entry, keep going
+                result["errors"].append(f"{entry.get('name', '?')}: {exc}")
+
+    return result
 
 
 def encrypt_file(data: bytes) -> bytes:

--- a/migrations/versions/c1a2b3d4e5f6_add_barcode_to_game.py
+++ b/migrations/versions/c1a2b3d4e5f6_add_barcode_to_game.py
@@ -1,0 +1,47 @@
+"""add barcode (QR/label slug) to game
+
+Revision ID: c1a2b3d4e5f6
+Revises: 7a61de1d1679
+Create Date: 2026-07-08 22:10:00.000000
+
+Adds a stable, unique ``barcode`` slug to each game (used by the QR label /
+USB-scanner lookup) and backfills a deterministic name-derived slug for every
+existing row.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c1a2b3d4e5f6'
+down_revision = '7a61de1d1679'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # 1. Add the column (nullable for now, so the backfill can populate it).
+    with op.batch_alter_table('game', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('barcode', sa.String(length=64), nullable=True))
+
+    # 2. Backfill a deterministic, unique slug for every existing game.
+    from app.utils.helpers import generate_unique_barcode
+
+    bind = op.get_bind()
+    rows = bind.execute(sa.text("SELECT id, name FROM game ORDER BY id")).fetchall()
+    taken: set[str] = set()
+    for row in rows:
+        slug = generate_unique_barcode(row.name or f"game-{row.id}", taken)
+        bind.execute(
+            sa.text("UPDATE game SET barcode = :b WHERE id = :i"),
+            {"b": slug, "i": row.id},
+        )
+
+    # 3. Enforce uniqueness now that values exist.
+    op.create_index('ix_game_barcode', 'game', ['barcode'], unique=True)
+
+
+def downgrade():
+    op.drop_index('ix_game_barcode', table_name='game')
+    with op.batch_alter_table('game', schema=None) as batch_op:
+        batch_op.drop_column('barcode')

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ python-dotenv==1.2.2
 Flask-Limiter==4.1.1
 requests==2.32.5
 Pillow==12.1.1
+segno==1.6.6  # QR code generation for machine labels
 
 # Raspberry Pi hardware integration (skeeball lanes, GPIO, serial)
 gpiozero==2.0.1

--- a/templates/base.html
+++ b/templates/base.html
@@ -203,8 +203,10 @@
                     <a href="{{ url_for('games.games_list') }}" class="nav-dropdown-toggle">Games</a>
                     <div class="nav-dropdown-menu">
                         <a href="{{ url_for('games.games_list') }}">All Games</a>
+                        <a href="{{ url_for('games.scan') }}"> Scan Machine</a>
                         {% if current_user.has_role('manager') %}
                         <a href="{{ url_for('games.add_game') }}">Add Game</a>
+                        <a href="{{ url_for('games.import_games') }}">Import JSON</a>
                         {% endif %}
                         <a href="{{ url_for('skeeball.skeeball_home') }}"> Skeeball</a>
                     </div>

--- a/templates/game_detail.html
+++ b/templates/game_detail.html
@@ -59,6 +59,7 @@
         {% if current_user.has_role('manager') %}
             <a href="{{ url_for('games.edit_game', game_id=game.id) }}" class="btn" style="background: var(--neon-purple); width: 100%; margin-bottom: 10px;"> Edit Game</a>
         {% endif %}
+        <a href="{{ url_for('games.game_label', game_id=game.id) }}" class="btn" style="background: var(--neon-blue, #00d9ff); color:#000; width: 100%; margin-bottom: 10px;"> Print QR Label</a>
         <a href="https://www.arcade-museum.com/Videogame/{{ game.name.lower().replace(' ', '-').replace('.','-').replace('!','').replace('&','and').replace('(','').replace(')','').replace(':','').replace("'","") }}#manuals" target="_blank" rel="noopener noreferrer" class="btn" style="background: var(--neon-green); width: 100%; margin-bottom: 10px;"> View Manual</a>
         <a href="{{ url_for('games.games_list') }}" class="btn" style="width: 100%;">Back to All Games</a>
     </div>

--- a/templates/game_label.html
+++ b/templates/game_label.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block title %}Label — {{ game.name }}{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="page-header no-print">
+        <h1>Machine Label</h1>
+        <div>
+            <button onclick="window.print()" class="btn btn-primary">Print Label</button>
+            <a href="{{ url_for('games.game_detail', game_id=game.id) }}" class="btn btn-secondary">Back</a>
+        </div>
+    </div>
+
+    <div class="label-card">
+        <img src="{{ qr_data_uri }}" alt="QR code" class="label-qr">
+        <div class="label-name">{{ game.name }}</div>
+        {% if game.manufacturer %}<div class="label-mfr">{{ game.manufacturer }}</div>{% endif %}
+        <div class="label-code">{{ game.barcode }}</div>
+    </div>
+
+    <p class="no-print" style="margin-top: 16px; opacity: 0.8; font-size: 0.9em;">
+        Scanning this label with the USB scanner (on the
+        <a href="{{ url_for('games.scan') }}">Scan</a> page) or a phone camera opens
+        this machine's maintenance page. Encoded link: <code>{{ label_url }}</code>
+    </p>
+</div>
+
+<style>
+    .label-card {
+        display: inline-block;
+        text-align: center;
+        padding: 16px 20px;
+        border: 2px solid #000;
+        border-radius: 8px;
+        background: #fff;
+        color: #000;
+    }
+    .label-qr { width: 220px; height: 220px; display: block; margin: 0 auto 8px; }
+    .label-name { font-size: 1.3em; font-weight: bold; }
+    .label-mfr { font-size: 0.95em; }
+    .label-code { font-family: monospace; font-size: 0.8em; margin-top: 4px; opacity: 0.7; }
+
+    @media print {
+        .no-print, .nav, .theme-toggle { display: none !important; }
+        body, .container { background: #fff !important; }
+        .label-card { border: 1px solid #000; }
+    }
+</style>
+{% endblock %}

--- a/templates/games_list.html
+++ b/templates/games_list.html
@@ -6,9 +6,13 @@
 <div class="container">
     <div class="page-header">
         <h1> Arcade Games Database</h1>
-        {% if current_user.has_role('manager') %}
-        <a href="{{ url_for('games.add_game') }}" class="btn btn-primary"> Add New Game</a>
-        {% endif %}
+        <div>
+            <a href="{{ url_for('games.scan') }}" class="btn btn-secondary"> Scan</a>
+            {% if current_user.has_role('manager') %}
+            <a href="{{ url_for('games.import_games') }}" class="btn btn-secondary"> Import JSON</a>
+            <a href="{{ url_for('games.add_game') }}" class="btn btn-primary"> Add New Game</a>
+            {% endif %}
+        </div>
     </div>
 
     <!-- Search and Filter Form -->

--- a/templates/import_games.html
+++ b/templates/import_games.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}Import Games{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="page-header">
+        <h1>Import Games from JSON</h1>
+        <a href="{{ url_for('games.games_list') }}" class="btn btn-secondary">Back to Games</a>
+    </div>
+
+    <div class="filters" style="max-width: 640px;">
+        <p style="margin-bottom: 16px;">
+            Upload a barcade-roster JSON file (with <code>video_games</code>,
+            <code>pinball</code>, and/or <code>retired</code> arrays). Games are matched
+            by name, so re-uploading the same file will <strong>not</strong> create
+            duplicates &mdash; only new machines are added.
+        </p>
+
+        <form method="POST" action="{{ url_for('games.import_games') }}" enctype="multipart/form-data">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            <div class="filter-row">
+                <input type="file" name="file" accept=".json,application/json" required class="form-control">
+                <button type="submit" class="btn btn-primary">Import</button>
+            </div>
+        </form>
+
+        <p style="margin-top: 16px; opacity: 0.8; font-size: 0.9em;">
+            Imported machines default to <strong>Floor</strong> (retired entries go to
+            Warehouse), and each gets a stable QR/label code generated from its name.
+        </p>
+    </div>
+</div>
+{% endblock %}

--- a/templates/scan.html
+++ b/templates/scan.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block title %}Scan Machine{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="page-header">
+        <h1>Scan a Machine</h1>
+        <a href="{{ url_for('games.games_list') }}" class="btn btn-secondary">Back to Games</a>
+    </div>
+
+    <div class="filters" style="max-width: 640px;">
+        <p style="margin-bottom: 16px;">
+            Put the cursor in the box below and scan a machine's QR/barcode label with
+            the USB scanner. You'll jump straight to that machine's maintenance page.
+        </p>
+
+        <form id="scanForm" onsubmit="return goToCode();">
+            <div class="filter-row">
+                <input type="text" id="scanbox" name="code" autocomplete="off"
+                       autofocus placeholder="Scan or type a code..." class="form-control"
+                       style="font-size: 1.2em; letter-spacing: 1px;">
+                <button type="submit" class="btn btn-primary">Go</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+    // A USB HID scanner "types" the label payload then presses Enter.
+    // The payload may be a bare code (e.g. "centipede") or a full URL
+    // (e.g. "https://host/g/centipede") if the QR encodes a link — handle both.
+    function goToCode() {
+        var raw = document.getElementById('scanbox').value.trim();
+        if (!raw) return false;
+        var code = raw;
+        if (raw.indexOf('/') !== -1) {
+            var parts = raw.replace(/\/+$/, '').split('/');
+            code = parts[parts.length - 1];
+        }
+        window.location = '/g/' + encodeURIComponent(code);
+        return false;
+    }
+
+    // Keep the box focused so every scan lands here.
+    var box = document.getElementById('scanbox');
+    box.focus();
+    document.addEventListener('click', function () { box.focus(); });
+</script>
+{% endblock %}


### PR DESCRIPTION
Recover the barcade roster after data loss and tie physical cabinets to their maintenance page.

Roster import (manager-only upload on the Games page):
- app/utils/helpers.py: import_games_from_roster() ingests the barcade-roster schema (video_games / pinball / retired + meta.platforms), mapping name, manufacturer, location (Floor; retired -> Warehouse), and packing each platform's faults/parts/PM plus per-entry risk/faults/notes into the notes.
- Idempotent: skips games already in the DB by name, so re-uploading never duplicates. Distinct machines sharing a name (Batman video + pinball) both import with unique barcode slugs.

QR label + USB-scanner lookup:
- Game.barcode: stable, name-derived slug (migration c1a2b3d4e5f6 adds the column + unique index and backfills existing rows). Deterministic so a rebuilt DB regenerates the same slugs and printed labels keep resolving.
- /game/<id>/label prints a QR (segno) encoding {BASE_URL}/g/<slug>.
- /scan kiosk page for the USB HID scanner; /g/<code> resolves a scanned code to that machine's maintenance page. Phone-camera scans of the same QR work when BASE_URL is set.
- requirements: segno; config: BASE_URL.

Targets the app/ blueprint package (the deployed app). Legacy app.py untouched.