### PR TITLE
Add one-way Postgres sync for homelab backup and reporting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,14 @@ AWS_BUCKET_NAME=your-unique-bucket-name
 AWS_REGION=us-east-1
 
 # Database Configuration (Optional)
+# The app itself always runs against local SQLite - do not point DATABASE_URL
+# at a remote DB, catbox's internet is not reliable enough for that.
 # DATABASE_URL=sqlite:///arcade.db
+
+# Homelab Postgres mirror (Optional - see POSTGRES_SYNC.md)
+# Target for scripts/sync_to_postgres.py. Only that script reads this; the
+# live app is unaffected whether or not it's set.
+# POSTGRES_SYNC_URL=postgresql://arcade:password@homelab-host:5432/arcade
 
 # Public base URL baked into printed QR machine labels (Optional).
 # Set this so phone-camera scans of a label open the app directly.

--- a/POSTGRES_SYNC.md
+++ b/POSTGRES_SYNC.md
@@ -1,0 +1,71 @@
+# Homelab Postgres Sync
+
+The app itself always runs against local SQLite at catbox — that's what
+`DATABASE_URL` points to by default (`app/__init__.py`), and it stays that
+way. Catbox's internet connection isn't reliable enough to be a hard
+dependency for every request the app makes, so Postgres is **not** the live
+database the app talks to.
+
+Instead, `scripts/sync_to_postgres.py` is a one-way mirror: it upserts every
+row from the local SQLite DB into a Postgres instance on your homelab,
+whenever it's run and the network happens to be up. If catbox is offline, the
+sync just fails and retries on its next scheduled run — nothing is lost,
+since it re-reads current SQLite state each time rather than diffing/queuing
+individual changes.
+
+## One-time setup
+
+1. On the homelab box, create a database and user:
+   ```sql
+   CREATE DATABASE arcade;
+   CREATE USER arcade WITH PASSWORD 'change-me';
+   GRANT ALL PRIVILEGES ON DATABASE arcade TO arcade;
+   ```
+2. On catbox, add to `.env`:
+   ```
+   POSTGRES_SYNC_URL=postgresql://arcade:change-me@homelab-host:5432/arcade
+   ```
+3. Install the Postgres driver (already in `requirements.txt`):
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Run it once by hand to confirm connectivity and let it create the schema:
+   ```bash
+   python scripts/sync_to_postgres.py
+   ```
+   The first run creates all tables on the Postgres side (via SQLAlchemy
+   metadata, mirroring the current models) and copies every row.
+
+## Scheduling it
+
+Copy the unit files and enable the timer so it runs automatically every 10
+minutes:
+
+```bash
+sudo cp arcade-tracker-sync.service arcade-tracker-sync.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now arcade-tracker-sync.timer
+```
+
+Check status / logs:
+
+```bash
+systemctl status arcade-tracker-sync.timer
+journalctl -u arcade-tracker-sync.service -f
+```
+
+Adjust `OnUnitActiveSec` in `arcade-tracker-sync.timer` if you want it more
+or less frequent.
+
+## Notes / limitations
+
+- This is a **mirror for backup and reporting**, not live shared state.
+  Don't run reports against the homelab copy expecting it to be perfectly
+  current — it's as fresh as the last successful sync.
+- Every run re-syncs the full DB (upsert by primary key). For an arcade this
+  size that's cheap and simple; it avoids needing change-tracking columns or
+  a write-queue.
+- If you ever add a feature that needs catbox and home to see the *same*
+  live data in real time (not just a periodic mirror), that's a different,
+  bigger architecture (Postgres becomes the primary DB, and every write path
+  at catbox needs an offline queue-and-replay layer). Not needed today.

--- a/arcade-tracker-sync.service
+++ b/arcade-tracker-sync.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Sync Arcade Tracker DB to homelab Postgres
+After=network.target
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=jackiegreybard
+Group=jackiegreybard
+WorkingDirectory=/home/jackiegreybard/arcade-tracker
+EnvironmentFile=/home/jackiegreybard/arcade-tracker/.env
+ExecStart=/home/jackiegreybard/arcade-tracker/venv/bin/python /home/jackiegreybard/arcade-tracker/scripts/sync_to_postgres.py
+StandardOutput=journal
+StandardError=journal

--- a/arcade-tracker-sync.timer
+++ b/arcade-tracker-sync.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run arcade-tracker-sync every 10 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=10min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,6 @@ matplotlib==3.10.8
 
 # Optional: shipping/tracking integration (lazy-imported)
 easypost==10.6.0
+
+# Optional: Postgres driver for scripts/sync_to_postgres.py (homelab DB mirror)
+psycopg2-binary==2.9.10

--- a/scripts/sync_to_postgres.py
+++ b/scripts/sync_to_postgres.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Mirror the local SQLite arcade DB into a homelab Postgres instance.
+
+The app keeps running against local SQLite (see app/__init__.py) so it never
+depends on catbox's internet connection. This script is a one-way, run-it-
+whenever sync: it upserts every row from SQLite into POSTGRES_SYNC_URL, for
+reporting/backup purposes on the homelab side.
+
+Safe to run on a timer with no network: failures are caught and logged, and
+the next scheduled run just retries (every row is upserted by primary key, so
+re-running after a partial or failed sync never duplicates anything).
+
+Usage:
+    POSTGRES_SYNC_URL=postgresql://user:pass@homelab-host:5432/arcade \
+        python scripts/sync_to_postgres.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import SQLAlchemyError
+
+from app import create_app
+from app.extensions import db
+
+CHUNK_SIZE = 500
+
+
+def _fix_sequence(dest, table_name: str, pk_col: str) -> None:
+    """Advance table_name's serial sequence past the mirrored id values.
+
+    No-ops if the column isn't backed by a sequence (e.g. composite-key
+    association tables), via the IS NOT NULL guard. table_name/pk_col come
+    from our own SQLAlchemy metadata, never user input.
+    """
+    dest.execute(
+        text(
+            f"""
+            DO $$
+            DECLARE seq text;
+            BEGIN
+                seq := pg_get_serial_sequence('{table_name}', '{pk_col}');
+                IF seq IS NOT NULL THEN
+                    PERFORM setval(
+                        seq,
+                        COALESCE((SELECT MAX("{pk_col}") FROM "{table_name}"), 1)
+                    );
+                END IF;
+            END $$;
+            """
+        )
+    )
+
+
+def sync() -> None:
+    postgres_url = os.environ.get("POSTGRES_SYNC_URL")
+    if not postgres_url:
+        print("POSTGRES_SYNC_URL not set; nothing to sync.")
+        return
+
+    app = create_app()
+    with app.app_context():
+        sqlite_engine = db.engine
+        metadata = db.metadata
+
+        pg_engine = create_engine(postgres_url)
+        metadata.create_all(bind=pg_engine)  # idempotent; mirrors the current models
+
+        with sqlite_engine.connect() as source, pg_engine.begin() as dest:
+            for table in metadata.sorted_tables:
+                rows = [dict(row._mapping) for row in source.execute(select(table))]
+                if not rows:
+                    continue
+
+                pk_cols = [c.name for c in table.primary_key.columns]
+                update_cols = [c.name for c in table.columns if c.name not in pk_cols]
+
+                for i in range(0, len(rows), CHUNK_SIZE):
+                    chunk = rows[i : i + CHUNK_SIZE]
+                    stmt = pg_insert(table).values(chunk)
+                    if update_cols:
+                        stmt = stmt.on_conflict_do_update(
+                            index_elements=pk_cols,
+                            set_={name: stmt.excluded[name] for name in update_cols},
+                        )
+                    else:
+                        stmt = stmt.on_conflict_do_nothing(index_elements=pk_cols)
+                    dest.execute(stmt)
+
+                if len(pk_cols) == 1:
+                    _fix_sequence(dest, table.name, pk_cols[0])
+
+                print(f"{table.name}: synced {len(rows)} row(s)")
+
+
+if __name__ == "__main__":
+    try:
+        sync()
+    except SQLAlchemyError as exc:
+        print(f"Postgres sync failed (will retry next scheduled run): {exc}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
Adds a periodic sync mechanism to mirror the local SQLite arcade database to a Postgres instance on the homelab for backup and reporting purposes. The app continues to run exclusively against local SQLite (ensuring it doesn't depend on unreliable internet connectivity), while a new script syncs data one-way to Postgres on a schedule.

## Key Changes
- **New sync script** (`scripts/sync_to_postgres.py`): Upserts all rows from SQLite to Postgres in chunks, handling both simple and composite primary keys. Includes automatic sequence advancement for auto-increment columns.
- **Systemd integration**: Added `arcade-tracker-sync.service` and `arcade-tracker-sync.timer` for automatic execution every 10 minutes.
- **Documentation** (`POSTGRES_SYNC.md`): Comprehensive setup guide covering one-time configuration, scheduling, and architectural notes about the mirror-only design.
- **Configuration**: Updated `.env.example` to document the new `POSTGRES_SYNC_URL` variable and clarify that `DATABASE_URL` should remain local SQLite.
- **Dependencies**: Added `psycopg2-binary` for Postgres connectivity.

## Implementation Details
- The sync is idempotent and safe to run on a timer with no network: failures are caught and logged, and the next run retries by re-reading current SQLite state.
- Uses SQLAlchemy's `on_conflict_do_update` for Postgres upserts, avoiding duplicates on re-runs.
- Automatically creates the schema on the Postgres side by mirroring SQLAlchemy metadata.
- Handles tables with and without auto-increment sequences via conditional SQL.
- Processes rows in chunks (500 at a time) for efficiency.

https://claude.ai/code/session_019ytMWkjxgR7gc4hXApNUnw